### PR TITLE
Use Aerospike DurableDelete to prevent Zombies

### DIFF
--- a/beanspike.go
+++ b/beanspike.go
@@ -10,6 +10,8 @@ import (
 	as "github.com/aerospike/aerospike-client-go"
 )
 
+var defaultPolicy = &as.WritePolicy{DurableDelete: true}
+
 type Conn struct {
 	aerospike    *as.Client
 	clientID     string

--- a/conn.go
+++ b/conn.go
@@ -160,7 +160,7 @@ func (conn *Conn) Delete(name string) error {
 			return err
 		}
 
-		_, err = client.Delete(policy, key)
+		_, err = client.Delete(defaultPolicy, key)
 		if err != nil {
 			return err
 		}

--- a/conn.go
+++ b/conn.go
@@ -168,16 +168,13 @@ func (conn *Conn) Delete(name string) error {
 		conn.stats("tube.delete.count", name, float64(1))
 	}
 
-	policy := as.NewWritePolicy(0, 0)
-	policy.DurableDelete = true
-
 	tk, _ := as.NewKey(AerospikeNamespace, AerospikeMetadataSet, name+":"+AerospikeKeySuffixTtr)
-	client.Delete(policy, tk)
+	client.Delete(defaultPolicy, tk)
 
 	dk, _ := as.NewKey(AerospikeNamespace, AerospikeMetadataSet, name+":"+AerospikeKeySuffixDelayed)
-	client.Delete(policy, dk)
+	client.Delete(defaultPolicy, dk)
 
-	err = client.DropIndex(policy, AerospikeNamespace, name, "idx_tube_"+name+"_"+AerospikeNameStatus)
+	err = client.DropIndex(defaultPolicy, AerospikeNamespace, name, "idx_tube_"+name+"_"+AerospikeNameStatus)
 
 	if err != nil {
 		return err

--- a/tube.go
+++ b/tube.go
@@ -157,7 +157,7 @@ func (tube *Tube) delete(id int64, genID uint32) (bool, error) {
 		}
 	}
 
-	ex, err := tube.Conn.aerospike.Delete(policy, key)
+	ex, err := tube.Conn.aerospike.Delete(defaultPolicy, key)
 	if err != nil {
 		if tube.Conn != nil {
 			tube.Conn.stats("tube.delete.count", tube.Name, float64(1))
@@ -290,9 +290,7 @@ func (tube *Tube) ReleaseWithRetry(id int64, delay time.Duration, incr, retryFla
 		key, err := as.NewKey(AerospikeNamespace, AerospikeMetadataSet, entry)
 
 		if err == nil {
-			policy := as.NewWritePolicy(0, 0)
-			policy.DurableDelete = true
-			client.Delete(policy, key)
+			client.Delete(defaultPolicy, key)
 		}
 	}
 
@@ -915,9 +913,7 @@ func (tube *Tube) deleteZombieEntries(n int) (int, error) {
 			tube.Delete(job)
 			count++
 		} else {
-			policy := as.NewWritePolicy(0, 0)
-			policy.DurableDelete = true
-			tube.Conn.aerospike.Delete(policy, res.Record.Key)
+			tube.Conn.aerospike.Delete(defaultPolicy, res.Record.Key)
 			count++
 		}
 	}


### PR DESCRIPTION
This repo already had lots of local policy objects, so just reused them