### PR TITLE
[BED-622] Incrementing the sequence for job IDs with batches.

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,60 @@
+package beanspike
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	server = "localhost"
+)
+
+func TestConn_newJobID(t *testing.T) {
+	t.Run("no concurrent Hot Key errors", func(t *testing.T) {
+		conn, err := Dial("", server, 3000, func(string, string, float64) {})
+		require.NoError(t, err)
+
+		const concurrency = 100
+		var start, wg sync.WaitGroup
+		var once sync.Once
+		ids := make(chan int64, concurrency)
+		done := make(chan struct{})
+
+		for i := 0; i < concurrency; i++ {
+			start.Add(1)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				start.Done()
+				<-done
+				once.Do(func() {
+					t.Logf("start %d connections", concurrency)
+				})
+
+				id, err := conn.newJobID()
+				assert.NoError(t, err)
+				ids <- id
+				t.Log(id)
+			}()
+		}
+		start.Wait()
+		close(done)
+		wg.Wait()
+		close(ids)
+
+		var got []int64
+		for i := range ids {
+			got = append(got, i)
+		}
+		assert.Equal(t, concurrency, len(got))
+		slices.Sort(got)
+		for i := 0; i < len(got)-1; i++ {
+			assert.Equal(t, int64(1), got[i+1]-got[i])
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,15 @@ require (
 	github.com/jmoiron/golz4 v0.0.0-20160608053201-27f83594ae3e
 	github.com/redsift/clockwork v1.8.0
 	github.com/redsift/go-stats v1.1.0
+	github.com/stretchr/testify v1.8.1
 )
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/redsift/go-errs v0.1.4 // indirect
 	github.com/redsift/go-foodfans v1.0.4 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
@@ -22,4 +25,5 @@ require (
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/tools v0.11.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=


### PR DESCRIPTION
### Problem
We have an auto-incremented ID for a new job in Beanspike based on a sequence `metadata.last` in the `beanspike` set. Concurrently creating many IDs leads to "Hot key" Aerospike errors.   

### Solution
Change the `newJobID()` function, which generates IDs, to increment the sequence in DB on a certain batch size and distribute that batch of IDs to the consumers.